### PR TITLE
Allow Multiple Inputs at once

### DIFF
--- a/src/__tests__/index.test.js
+++ b/src/__tests__/index.test.js
@@ -7,14 +7,39 @@ jest.mock('mathjs', () => {
 });
 
 describe('InlineCalculator', () => {
-  describe('Default config', () => {
-    let input;
+  let input;
+  const selector = '#inline-calculator',
+    submitInput = () => {
+      input.dispatchEvent(
+        new KeyboardEvent('keydown', {
+          key: 'Enter'
+        })
+      );
+    },
+    selectInput = () => {
+      input.dispatchEvent(new CustomEvent('focus'));
+    },
+    deselectInput = () => {
+      input.dispatchEvent(new CustomEvent('blur'));
+    },
+    cleanupEventListeners = () => {
+      document.body.parentNode.replaceChild(
+        document.body.cloneNode(true),
+        document.body
+      );
+    };
 
+  afterEach(() => {
+    cleanupEventListeners();
+  });
+
+  describe('Default config', () => {
     beforeEach(() => {
       document.body.innerHTML = '<input type="text" id="inline-calculator">';
-      new InlineCalculator();
-      input = document.querySelector('#inline-calculator');
+      new InlineCalculator({ selector });
+      input = document.querySelector(selector);
       input.value = '2 + 2';
+      selectInput();
     });
 
     it('should do nothing when wrong key is pressed', () => {
@@ -30,12 +55,7 @@ describe('InlineCalculator', () => {
 
     it('should update input value', () => {
       math.eval.mockReturnValueOnce(4);
-
-      input.dispatchEvent(
-        new KeyboardEvent('keydown', {
-          key: 'Enter'
-        })
-      );
+      submitInput();
 
       expect(math.eval).toBeCalledWith('2 + 2');
       expect(input.value).toBe('4');
@@ -47,32 +67,30 @@ describe('InlineCalculator', () => {
         throw new Error('you dun goofed');
       });
 
-      input.dispatchEvent(
-        new KeyboardEvent('keydown', {
-          key: 'Enter'
-        })
-      );
-
+      submitInput();
       expect(math.eval).toThrow('you dun goofed');
+    });
+
+    it('should not clear the input when calculating a non-calculation', () => {
+      input.value = '4';
+      submitInput();
+      expect(input.value).toBe('4');
     });
   });
 
   describe('Custom selector', () => {
     it('should accept a custom selector', () => {
-      let input;
       document.body.innerHTML = '<input type="text" class="inline-calculator">';
       new InlineCalculator({
         selector: '.inline-calculator'
       });
+
       input = document.querySelector('.inline-calculator');
       input.value = '2 + 2';
+      selectInput();
       math.eval.mockReturnValueOnce(4);
 
-      input.dispatchEvent(
-        new KeyboardEvent('keydown', {
-          key: 'Enter'
-        })
-      );
+      submitInput();
 
       expect(math.eval).toBeCalledWith('2 + 2');
       expect(input.value).toBe('4');
@@ -81,48 +99,71 @@ describe('InlineCalculator', () => {
 
   describe('onError callback', () => {
     it('should throw an error and fire the passed onError handler', () => {
-      let input;
-      let onErrorCallback = jest.fn();
+      let onError = jest.fn();
       document.body.innerHTML = '<input type="text" id="inline-calculator">';
-      new InlineCalculator({
-        onError: onErrorCallback
-      });
-      input = document.querySelector('#inline-calculator');
+      new InlineCalculator({ onError });
+      input = document.querySelector(selector);
       input.value = 'a + b';
+      selectInput();
       math.eval.mockImplementation(() => {
         throw new Error('you dun goofed');
       });
 
-      input.dispatchEvent(
-        new KeyboardEvent('keydown', {
-          key: 'Enter'
-        })
-      );
+      submitInput();
 
       expect(math.eval).toThrow('you dun goofed');
-      expect(onErrorCallback).toBeCalledWith('Error: you dun goofed');
+      expect(onError).toBeCalledWith('Error: you dun goofed');
     });
   });
 
   describe('onCalculated callback', () => {
     it('should fire the passed onCalculated handler', () => {
-      let input;
-      let onCalculatedCallback = jest.fn();
+      let onCalculated = jest.fn();
       document.body.innerHTML = '<input type="text" id="inline-calculator">';
       new InlineCalculator({
-        onCalculated: onCalculatedCallback
+        onCalculated
       });
-      input = document.querySelector('#inline-calculator');
-      input.value = 'a + b';
-      math.eval.mockReturnValueOnce('hello there');
+      input = document.querySelector(selector);
+      input.value = '1 + 2';
+      selectInput();
+      math.eval.mockReturnValueOnce('3');
 
-      input.dispatchEvent(
-        new KeyboardEvent('keydown', {
-          key: 'Enter'
-        })
-      );
+      submitInput();
 
-      expect(onCalculatedCallback).toBeCalledWith('hello there');
+      expect(onCalculated).toBeCalledWith('3');
+    });
+  });
+
+  describe('#initialize', () => {
+    it('should initialize with the default attribute', () => {
+      document.body.innerHTML =
+        '<input type="text" inline-calculator><input type="text" inline-calculator>';
+      let calculator = InlineCalculator.initialize();
+
+      expect(calculator.config.selector).toBe('[inline-calculator]');
+    });
+
+    it('should attach to multiple inputs', () => {
+      document.body.innerHTML =
+        '<input type="text" id="one" inline-calculator><input id="two" type="text" inline-calculator>';
+      InlineCalculator.initialize();
+
+      const interactWithInput = (id) => {
+        input = document.getElementById(id);
+        input.value = '4 + 2';
+        math.eval.mockReturnValueOnce('6');
+        selectInput();
+        input.dispatchEvent(
+          new KeyboardEvent('keydown', {
+            key: 'Enter'
+          })
+        );
+        expect(input.value).toBe('6');
+        deselectInput();
+      };
+
+      interactWithInput('one');
+      interactWithInput('two');
     });
   });
 });

--- a/src/__tests__/index.test.js
+++ b/src/__tests__/index.test.js
@@ -70,12 +70,6 @@ describe('InlineCalculator', () => {
       submitInput();
       expect(math.eval).toThrow('you dun goofed');
     });
-
-    it('should not clear the input when calculating a non-calculation', () => {
-      input.value = '4';
-      submitInput();
-      expect(input.value).toBe('4');
-    });
   });
 
   describe('Custom selector', () => {


### PR DESCRIPTION
## Details
* In order to allow backwards compatibility, I've added an `initialize` method which also conforms to the [no-new side effects eslint rule](https://eslint.org/docs/rules/no-new#rule-details).
* Now, for both the `new InlineCalculator` and `InlineCalculator.initialize()`:
	* `querySelectorAll` is used in place of `querySelector`
	* "Capturing Events" are set on the `document.body` to listen for `focus` and `blur` events.
	* These events are used to attach/detach the actual event listeners that do that math calculating, thus requiring only 2 event listeners for any number of inline calculators present on the page.

## Notes
* I was required to add listeners on the `document.body` because, in testing, there was no easy way to detach the listeners for each individual test. Without detaching the event listeners, they multiplied with each test.
* I added a check for the `typeof === 'function'` before running the `onError` and `onCalculated` callbacks, this will prevent them being called if they are a different type.

---

- Closes #1